### PR TITLE
fix timeout behavior for edit title success/ failure widget

### DIFF
--- a/client/src/components/Title.tsx
+++ b/client/src/components/Title.tsx
@@ -26,7 +26,7 @@ function Title({ noteId, title }: { noteId: string; title: string }) {
     }, 5000);
 
     return () => clearInterval(timer);
-  }, []);
+  }, [success, error]);
 
   const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setNewTitle(e.target.value);
@@ -113,6 +113,7 @@ function Title({ noteId, title }: { noteId: string; title: string }) {
         onKeyUp={() => setEditing(true)}
         role="button"
         tabIndex={0}
+        title="edit note title"
       >
         {title}
         {error && (


### PR DESCRIPTION
This PR modifies the useEffect dependency array in the Title component to only include `success` and `error`. Previously, the effect was running on every component render, resulting in inconsistent timeouts